### PR TITLE
Bump httpclient from 4.3.6 to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
                 <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.6</version>	
+            <version>4.5.13</version>	
         </dependency>
   
         <dependency>


### PR DESCRIPTION
Bumps httpclient from 4.3.6 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient dependency-type: direct:production ...